### PR TITLE
モーダルウィンドウが非表示時に完全に見えないように変更

### DIFF
--- a/css/modal.css
+++ b/css/modal.css
@@ -12,11 +12,13 @@ div#modal {
   width: 100%;
   height: 100%;
   margin-top: 100%;
+  opacity: 0;
   display: table-cell;
   z-index:9999;
 }
 div#modal.show {
   margin-top: 0;
+  opacity: 1;
 }
 div#modal div.background {
   display: none;


### PR DESCRIPTION
iOS 端末で，
1. 少しページを拡大
2. モーダルウィンドウを開く
3. モーダルウィンドウを閉じる
4. ピンチでかなり縮小する（この時手は離さない）
を行った時に，
ページの下からモーダルウィンドウが現れるという現象が起こったので，
モーダルウィンドウ非表示時には完全に透明になるようにしました．